### PR TITLE
#70: Dependencies could be more fine grained

### DIFF
--- a/nuget/Poser.nuspec
+++ b/nuget/Poser.nuspec
@@ -20,9 +20,34 @@
 	  </releaseNotes>
 
     <dependencies>
-      <dependency id="Mono.Reflection.Core" version="1.1.1" />
-      <dependency id="System.Reflection.Emit.Lightweight" version="4.3.0" />
-      <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
+      <group>
+        <dependency id="Mono.Reflection.Core" version="1.1.1" />
+      </group>
+
+      <group targetFramework="netstandard2.0">
+        <dependency id="System.Reflection.Emit.Lightweight" version="4.3.0" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
+      </group>
+
+      <group targetFramework="netcoreapp2.0">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
+      </group>
+
+      <group targetFramework="netcoreapp3.0">
+      </group>
+
+      <group targetFramework="net48">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
+      </group>
+
+      <group targetFramework="net5.0">
+      </group>
+
+      <group targetFramework="net7.0">
+      </group>
+
+      <group targetFramework="net8.0">
+      </group>
     </dependencies>
   </metadata>
 

--- a/src/Pose/Pose.csproj
+++ b/src/Pose/Pose.csproj
@@ -11,9 +11,33 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants />
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Mono.Reflection.Core" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Describe your changes
The pull request optimizes the project's package dependencies by taking platform-specific requirements into account. Dependencies are now only declared for those frameworks that actually need them. The corresponding changes were verified using [.NET API browser](https://learn.microsoft.com/en-us/dotnet/api).

## Issue ticket number and link
Relates to issue #70.